### PR TITLE
Change the ant_ when zsc exist

### DIFF
--- a/9_child_anthropometrics.do
+++ b/9_child_anthropometrics.do
@@ -4,23 +4,27 @@
 ******************************   
 
 *c_stunted: Child under 5 stunted
-    foreach var in hc70 hc71 {
-    replace `var'=. if `var'>900
-    replace `var'=`var'/100
-    }
-    replace hc70=. if hc70<-6 | hc70>6
-    replace hc71=. if hc71<-6 | hc71>5
+ keep hvidx hv001 hv002 hv005 hv103 hc70 hc71
+ gen ant_sampleweight = hv005/1000000
+ 
+ drop if hv103==0
+ ren hv001 v001 
+ ren hv002 v002
+ ren hvidx b16
+ 
+ foreach var in hc70 hc71 {
+ replace `var'=. if `var'>900
+ replace `var'=`var'/100
+ }
+ replace hc70=. if hc70<-6 | hc70>6
+ replace hc71=. if hc71<-6 | hc71>5
+ gen c_stunted=1 if hc70<-2
+ replace c_stunted=0 if hc70>=-2 & hc70!=.
+ gen c_underweight=1 if hc71<-2
+ replace c_underweight=0 if hc71>=-2 & hc71!=.
 
-    gen c_stunted=1 if hc70<-2
-    replace c_stunted=0 if hc70>=-2 & hc70!=.
 
-*c_underweight: Child under 5 underweight
-    gen c_underweight=1 if hc71<-2
-    replace c_underweight=0 if hc71>=-2 & hc71!=.
 
 							
-*ant_sampleweight Child anthropometric sampling weight
-    gen ant_sampleweight = hv005/10e6
 
 
-	


### PR DESCRIPTION
Update the 9_child_anthropometrics, and DHS_Recod_V.do for the cases where zsc exist.

Haozheyi could you kindly test it as I can not open the zsc.dta files in the raw data folder for Recodev V. (For example, test it with DHS-Zimbabwe2005)

Best, 
Aline